### PR TITLE
LTO - link time optimization

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/jfc/latest/jfc/"
 [lints.rust]
 unsafe_code = "forbid"
 
+[profile.release]
+lto = true
+
 [dependencies]
 clap = { version = "4.5", features = ["cargo"] }
 toy-json-formatter = { version = "0.3", path = "../json/" }

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,7 +10,7 @@ JSON Formatting CLI (JFC) is a CLI tool written in Rust for working with malform
 
 ## Installation
 To install JFC: 
-1. Install the rust toolchain following the directions on [doc.rust-land.org](https://doc.rust-lang.org/cargo/getting-started/installation.html) to install cargo.
+1. Install the rust toolchain following the directions on [doc.rust-lang.org](https://doc.rust-lang.org/cargo/getting-started/installation.html) to install cargo.
 2. Switch to the unstable rust toolchain by running `rustup override set nightly`
 3. Run `cargo install jfc`
 4. Switch back to the stable rust toolchain by running `rustup override set stable`


### PR DESCRIPTION
This pull request add link time optimization to the release profile to reduce the size of the compiled binary.